### PR TITLE
bumps ubuntu release--kubeadm seems to try to install a mismatch of p…

### DIFF
--- a/2-kube-controller.tf
+++ b/2-kube-controller.tf
@@ -13,7 +13,7 @@ data "template_file" "controller" {
 
 resource "packet_device" "k8s_primary" {
   hostname         = "${var.cluster_name}-controller"
-  operating_system = "ubuntu_16_04"
+  operating_system = "ubuntu_18_04"
   plan             = "${var.plan_primary}"
   facility         = "${var.facility}"
   user_data        = "${data.template_file.controller.rendered}"

--- a/modules/node_pool/main.tf
+++ b/modules/node_pool/main.tf
@@ -22,7 +22,7 @@ data "template_file" "node" {
 
 resource "packet_device" "x86_node" {
   hostname         = "${format("${var.cluster_name}-x86-${var.pool_label}-%02d", count.index)}"
-  operating_system = "ubuntu_16_04"
+  operating_system = "ubuntu_18_04"
   count            = "${var.count_x86}"
   plan             = "${var.plan_x86}"
   facility         = "${var.facility}"
@@ -34,7 +34,7 @@ resource "packet_device" "x86_node" {
 
 resource "packet_device" "arm_node" {
   hostname         = "${format("${var.cluster_name}-arm-${var.pool_label}-%02d", count.index)}"
-  operating_system = "ubuntu_16_04"
+  operating_system = "ubuntu_18_04"
   count            = "${var.count_arm}"
   plan             = "${var.plan_arm}"
   facility         = "${var.facility}"


### PR DESCRIPTION
…ackages that breaks installation (i.e. outside of our control here) on 16.04 even when a version is not specified for the kubeadm package, does not occur on 18.04 using the xenial ppa