### PR TITLE
adds back-off timer to address issue #35; control plane nodes joining…

### DIFF
--- a/modules/controller_pool/controller-standby.tpl
+++ b/modules/controller_pool/controller-standby.tpl
@@ -35,4 +35,6 @@ if [ "${ceph}" = "yes" ]; then
 fi ; \
 enable_docker && \
 install_kube_tools && \
-sleep 180
+sleep 180 ; \
+backoff_count=`echo $((5 + RANDOM % 100))` ; \
+sleep $backoff_count


### PR DESCRIPTION
… at the same time can corrupt etcd datastore; this adds a random backoff value so they're not joining so closely to each other

Addresses #35 